### PR TITLE
Add JustBlogged - zero-setup blogging platform

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,7 @@
 - **MailerLite:** e-mail marketing acessível.  
 - **Loops.so:** automação de e-mails focada em SaaS.  
 - **Beehiiv:** newsletters com foco em criadores.  
+- **[JustBlogged](https://justblogged.com/):** plataforma de blog sem configuração — cadastre-se, escolha um nome e comece a escrever em 2 minutos. SEO integrado, domínios personalizados, temas bonitos. Grátis para sempre, Pro por $9/mês.
 - **Crisp:** chat de suporte no site.  
 - **[Curso de Marketing pra Devs](https://go.hotmart.com/V84728655X):** Feito pela Danki Code.  
 


### PR DESCRIPTION
Adding [JustBlogged](https://justblogged.com/) under Marketing — a zero-setup blogging platform. Sign up, pick a name, start writing in 2 minutes. Built-in SEO, custom domains, beautiful themes. Free forever, $9/mo Pro.