### PR TITLE
Add Sprint Fixer in new Consultoria & Serviços section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,9 @@
 - **Discourse:** fórum open source.
 - **Docsify:** ferramenta leve para criar sites de documentação a partir de arquivos Markdown.
 
+## Consultoria & Serviços
+- **[Sprint Fixer](https://sasn19.github.io/sprint-fixer/):** sprint de 48h com preço fixo pra desbloquear um item específico do seu lançamento — integração Stripe, fluxo de auth, deploy travado ou bug de upgrade. Pagamento em USDC na Base mainnet, sem signup, sem cartão. $249/sprint, $599/3 sprints, $899/recon de fundador.
+
 
 
 Vou continuar adicionando outras ferramentas.


### PR DESCRIPTION
## O que muda
Adiciona uma nova seção **Consultoria & Serviços** ao final da lista, com a primeira entrada: **Sprint Fixer**.

## Por que essa seção
A lista atual cobre muito bem **ferramentas** (infra, frontend, pagamentos, auth, etc.) que indie hackers usam pra construir o produto. Mas não tem nada cobrindo **serviços de execução** — quando o indie hacker tem o stack pronto e fica travado em uma coisa específica do lançamento (Stripe webhook que não dispara, refresh token quebrado, deploy infinito), uma seção de serviços ajuda a fechar essa lacuna.

## Sobre o Sprint Fixer
- **Modelo:** sprint de 48h, escopo único, preço fixo.
- **Pagamento:** USDC direto na carteira na Base mainnet — sem signup, sem cartão, sem plataforma intermediária. Verificável on-chain.
- **Tiers:** $249 (1 sprint) · $599 (3 sprints) · $899 (recon de fundador).
- **Garantia:** reembolso na mesma carteira em 48h se não desbloqueado.
- **Landing:** https://sasn19.github.io/sprint-fixer/

Aberto a feedback no formato da entrada ou no posicionamento da seção. Posso renomear pra "Serviços", mover de lugar, ou enxugar a descrição se preferir.