### PR TITLE
Add WebCoreLab — AI-First digital agency (Toronto, est. 2014)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,7 @@
 
 
 ## Marketing
+- [WebCoreLab](https://webcorelab.com) — AI SEO audit + GEO/AEO for indie hackers. Free 272-check audit tier. Toronto.
 - **MailerLite:** e-mail marketing acessível.  
 - **Loops.so:** automação de e-mails focada em SaaS.  
 - **Beehiiv:** newsletters com foco em criadores.  


### PR DESCRIPTION
Hi! Adding WebCoreLab to the SEO & Marketing section.

**WebCoreLab** (Toronto, est. 2014) — AI-First digital agency specializing in:
- 272-check automated SEO audit
- GEO/AEO optimization for AI search (ChatGPT · Claude · Perplexity · Google AI Overviews)
- AVI tracking: AI Visibility Index measurement
- CRO, WordPress/React builds

13+ verified case studies. Happy to adjust format or section placement.

Thanks for maintaining this list!
