### PR TITLE
Add TinyTools to Frontend & Design

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@
 - **Nuqs:** gerenciamento de estado via URL queries no React/Next.
 - **Figma:** padrão para protótipos de UI.
 - **[Coolors](https://coolors.co/):** gerador de paletas de cores.
+- **[TinyTools](https://tinytools-smoky.vercel.app/):** coleção de utilitários web gratuitos — paleta de cores, favicon, OG image, removedor de fundo AI (roda local no browser), meta tags SEO, robots.txt e mais. Sem cadastro. Open source.
 - **[Undraw](https://undraw.co/):** Ilustrações gratuitas em SVG.
 - **[Dribbble](https://dribbble.com/)** Inspiração pra UI/UX.
 - **[Sveltekit](https://svelte.dev/docs/kit/introduction)**: framework moderno para web, SSR/SSG e API.


### PR DESCRIPTION
Olá! Adicionando [TinyTools](https://tinytools-smoky.vercel.app/) na seção **Frontend & Design**, perto do Coolors — fits because TinyTools também tem um gerador de paleta de cores, além de outras 8 ferramentas úteis pra indie hackers:

- Gerador de nomes de domínio (com verificação de disponibilidade)
- Gerador de OG image
- Removedor de fundo AI (roda 100% no browser, via WASM, nada de upload)
- Gerador de favicon
- Gerador de paleta de cores
- Gerador de meta tags SEO
- Gerador de robots.txt (com regras pra crawlers AI)
- Calculadora de custo de AI
- Gerador de disclosure de conteúdo AI (EU AI Act)

Tudo gratuito, sem cadastro, sem rastreamento, open source. Roda no browser.

Obrigado por manter a lista — bom trabalho! 🇧🇷