### PR TITLE
Add The Free X Growth Course

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,7 @@
 - **Beehiiv:** newsletters com foco em criadores.  
 - **Crisp:** chat de suporte no site.  
 - **[Curso de Marketing pra Devs](https://go.hotmart.com/V84728655X):** Feito pela Danki Code.  
+- **[The Free X Growth Course](https://slappost.app/learn/):** 5 aulas gratuitas (sem login) sobre como crescer no X (Twitter): hooks, threads, o algoritmo open source do X, replies e o funil do seu perfil.  
 
 ## Comunidade & Suporte
 - **Docusaurus:** documentação estilo docs.dev.  


### PR DESCRIPTION
Adds **The Free X Growth Course** (https://slappost.app/learn/) to the **Marketing** section, alongside the existing course entry. It's 5 completely free lessons on growing on X (Twitter) — hooks, threads, X's open-source algorithm, replies, and the profile funnel — with no login, no email wall, and no paywall. Thanks for maintaining this list of indie-hacker resources!