### PR TITLE
Adiciona Autoposting em Marketing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,7 @@
 - **Beehiiv:** newsletters com foco em criadores.  
 - **Crisp:** chat de suporte no site.  
 - **[Curso de Marketing pra Devs](https://go.hotmart.com/V84728655X):** Feito pela Danki Code.  
+- [Autoposting](https://autoposting.ai) - AI social media manager: generates posts in your own voice, clips long video, builds carousels, and schedules to X, LinkedIn, Instagram, Threads and YouTube
 
 ## Comunidade & Suporte
 - **Docusaurus:** documentação estilo docs.dev.  


### PR DESCRIPTION
Adiciona [Autoposting](https://autoposting.ai) na seção Marketing.

Gerenciador de redes sociais com IA: escreve posts no seu tom de voz, corta vídeos longos em clipes, monta carrosséis e agenda para X, LinkedIn, Instagram, Threads e YouTube. Tem plano gratuito.

Uma linha adicionada, no mesmo formato dos itens vizinhos.