### PR TITLE
Adiciona Mentioned na secao Marketing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,7 @@
 - **Beehiiv:** newsletters com foco em criadores.  
 - **Crisp:** chat de suporte no site.  
 - **[Curso de Marketing pra Devs](https://go.hotmart.com/V84728655X):** Feito pela Danki Code.  
+- **[Mentioned](https://mentioned.to):** serviço gerenciado de crescimento no Reddit para SEO e busca com IA. Encontra as threads que já ranqueiam no Google para suas palavras-chave, publica posts e comentários nativos por contas gerenciadas e mede o share of voice contra concorrentes. Serviço pago, a partir de US$ 2.000/mês.  
 
 ## Comunidade & Suporte
 - **Docusaurus:** documentação estilo docs.dev.  


### PR DESCRIPTION
Adiciona uma entrada para o **Mentioned** (https://mentioned.to) na seção `Marketing`.

**O que é:** encontra as threads do Reddit que já ranqueiam no Google para as palavras-chave do cliente (e onde os concorrentes são recomendados), escreve e publica posts e comentários nativos a partir de contas gerenciadas, e reporta share of voice contra concorrentes.

**Transparência total, para você avaliar com justiça:**
- Eu trabalho no Mentioned — esta é uma auto-indicação, não uma contribuição neutra de terceiros.
- É um **serviço gerenciado pago**, não um software self-serve. Planos a partir de **US$ 2.000/mês**, sem plano gratuito e sem versão que você mesmo opere.
- Não é open source. Fundado em 2025.
- Ressalva honesta: esta lista é voltada a indie hackers, e o resto das ferramentas aqui é barato ou gratuito. US$ 2.000/mês está fora do orçamento da maioria desse público. Se por isso não fizer sentido na lista, feche o PR sem problema algum.

Apenas uma linha adicionada, nada mais foi alterado. Obrigado por manter o repositório.
