### PR TITLE
Add n8n Uptime Ping Alert

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -102,3 +102,4 @@ Vou continuar adicionando outras ferramentas.
 
 Aproveita e conheça o starter Kit pro seu SaaS: [Arki](https://www.usearki.dev?utm_source=github)
 - [TaleForge](https://www.tale-forge.com) - Free creative writing platform with book, manga, and screenplay editors. Built-in marketplace for selling stories.
+- [n8n Uptime Ping Alert](https://github.com/DeusAcc/n8n-uptime-ping-alert) - Free n8n workflow that checks a site every 5 minutes and alerts on Telegram only on state change.


### PR DESCRIPTION
Adding a free, open-source n8n workflow (n8n Uptime Ping Alert) that fits this list.

The repo README documents usage and also links to a paid bundle at https://negozio.mooo.com/?src=lincolixavier-awesome-indie-hackers — the specific workflow linked here is itself free (no account/paywall).

Happy to adjust placement/wording if it doesn't fit.