### PR TITLE
Add Knocket to marketing/support tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,7 @@
 - **Loops.so:** automação de e-mails focada em SaaS.  
 - **Beehiiv:** newsletters com foco em criadores.  
 - **Crisp:** chat de suporte no site.  
+- **[Knocket](https://knocket.com/):** widget de live chat grátis pra sempre + página de contato compartilhável + inbox unificada (Telegram/email). Sem limite de assentos, sem anúncios.  
 - **[Curso de Marketing pra Devs](https://go.hotmart.com/V84728655X):** Feito pela Danki Code.  
 
 ## Comunidade & Suporte


### PR DESCRIPTION
Adiciona [Knocket](https://knocket.com) na seção de marketing/suporte.

Knocket é um widget de live chat grátis pra sempre + página de contato compartilhável + inbox unificada (Telegram/email). Sem limite de assentos, sem anúncios — perfeito pra indie hackers que precisam de suporte ao cliente sem custos recorrentes.