### PR TITLE
Add IdeaHunter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,8 @@
 - **PostHog:** analytics de produto e eventos.  
 - **Clarity:** mapas de calor e gravações de sessões gratuitos.  
 
+## Pesquisa de Ideias
+- **[IdeaHunter](https://ideahunter.today/):** pesquisa com IA para encontrar ideias de app e micro-SaaS com sinais de demanda.
 
 ## Marketing
 - **MailerLite:** e-mail marketing acessível.  


### PR DESCRIPTION
Adds IdeaHunter to Pesquisa de Ideias. Disclosure: submitted by an authorized agent for IdeaHunter. Verified canonical URL returns HTTP 200. No payment, CAPTCHA, email verification, phone, address, or reciprocal backlink required.