### PR TITLE
Add Shotlingo App Store Localization Checker to Internacionalização

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@
 - **Localize:** plataforma SaaS para tradução e i18n.
 - **Crowdin:** gestão de traduções colaborativas.
 - **Content Collections:** schemas tipados para conteúdo estático (Markdown/MDX).
+- **[Shotlingo App Store Localization Checker](https://shotlingo.com/tools/app-store-localization-checker):** ferramenta gratuita (sem cadastro) pra checar se o nome, subtítulo e texto promocional do teu app ainda cabem depois de traduzidos — expansão de texto, largura visual e RTL pras 41 línguas da App Store.
 
 ## Pagamentos 
 - **[AbacatePay](https://www.abacatepay.com/) 🥑:** gateway brasileiro para receber em BRL, focado em baixo custo.  


### PR DESCRIPTION
Adds one line to the **Internacionalização & Conteúdo** section, next to Localize/Crowdin.

[Shotlingo App Store Localization Checker](https://shotlingo.com/tools/app-store-localization-checker) — a free, no-signup tool that checks whether your App Store name/subtitle/promo text still fits after translation (text expansion, visual width, and RTL handling across all 41 App Store languages). Useful for indie devs shipping localized store listings alongside the SaaS-i18n tools already listed here.