### PR TITLE
Adiciona AnyHook em APIs & Serviços

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,7 @@
 ## APIs & Serviços
 - **Twilio:** SMS/WhatsApp e voz.  
 - **Algolia:** busca instantânea hospedada.  
+- **[AnyHook](https://anyhook.net):** relay de webhooks de entrada, guarda cada evento e reenvia quando a entrega falha. Plano free de 3.000 eventos/mês.
 
 ## Observabilidade
 - **Sentry:** captura de erros em produção.


### PR DESCRIPTION
Adicionei o AnyHook na seção APIs & Serviços.

É um relay para webhooks de entrada: você troca a URL que o Stripe, o GitHub ou a Meta chamam, e ele guarda o evento antes de entregar no seu servidor. Se a entrega falha, ele tenta de novo, e o corpo da requisição fica salvo pra você olhar depois.

Achei que cabia aqui porque resolve uma coisa chata pra quem tá tocando projeto sozinho: receber webhook exige um host público de pé o tempo todo, mesmo quando o handler tem vinte linhas.

Plano free de 3.000 eventos/mês, sem cartão.