### PR TITLE
Adiciona Hermes (agentes de voz com IA) em APIs & Serviços

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,7 @@
 ## APIs & Serviços
 - **Twilio:** SMS/WhatsApp e voz.  
 - **Algolia:** busca instantânea hospedada.  
+- **[Hermes](https://www.buildwithhermes.com):** plataforma white-label para criar e operar agentes de voz com IA, com CRM, campanhas e billing por minuto inclusos. Planos a partir de US$149/mês.  
 
 ## Observabilidade
 - **Sentry:** captura de erros em produção.


### PR DESCRIPTION
Oi! Ótima lista, muito útil pra quem tá começando um SaaS solo.

Adicionei o Hermes na seção **APIs & Serviços**, logo abaixo do Twilio, porque cobre uma lacuna que a lista ainda não tinha: agentes de voz com IA.

O Twilio resolve a telefonia crua. O Hermes é a camada acima, você cria o agente, conecta CRM e campanhas, e cobra do cliente final com sua própria marca. Pra indie hacker que quer vender atendimento por voz sem montar stack de 5 ferramentas, encurta bastante o caminho.

Detalhes:
- Site: https://www.buildwithhermes.com
- White-label completo, o cliente final não vê a marca Hermes
- CRM, orquestração de campanhas e billing por minuto inclusos
- Planos a partir de US$149/mês (300 min inclusos), depois US$399 e US$699

Divulgação: eu trabalho no Hermes. Se achar que não encaixa na lista, sem problema, pode fechar o PR.