### PR TITLE
Add Ibis under Frontend & Design

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,7 @@
 - **[Coolors](https://coolors.co/):** gerador de paletas de cores.
 - **[Undraw](https://undraw.co/):** Ilustrações gratuitas em SVG.
 - **[Dribbble](https://dribbble.com/)** Inspiração pra UI/UX.
+- **[Ibis](https://cartonpliant.github.io/ibis/):** compositor de página de oferta no navegador, sem conta. Grátis com marca d'água; Pro 9 € impressão limpa, Markdown e 5 gabaritos.
 - **[Sveltekit](https://svelte.dev/docs/kit/introduction)**: framework moderno para web, SSR/SSG e API.
 
 ## Internacionalização & Conteúdo


### PR DESCRIPTION
Adiciona [Ibis](https://cartonpliant.github.io/ibis/) em **Frontend & Design**.

Ibis é um compositor de página de oferta no navegador, sem conta. Grátis com marca d'água; Pro 9 € impressão limpa, Markdown e 5 gabaritos. Não é ferramenta de orçamento nem de fatura.

Sou o maker. URL: https://cartonpliant.github.io/ibis/